### PR TITLE
Add `engines.node` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "rollup": "^2.23.1",
     "rollup-plugin-esbuild": "^2.4.2",
     "typescript": "^3.9.7"
+  },
+  "engines": {
+    "node": ">=10.10.0"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/netlify/build/issues/1777

This adds an `engines.node` to the `package.json`. Netlify Build checks the current Node.js version against the supported Node.js version declared in that field. If the version is not supported, the plugin fails with a warning message notifying users that the plugin does not work with that Node.js version.