### PR TITLE
Change plugin name

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,4 +1,4 @@
-name: netlify-plugin-edge
+name: "@netlify/plugin-edge-handlers"
 inputs:
   - name: sourceDir
     default: "handlers"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "netlify-plugin-edge",
+  "name": "@netlify/plugin-edge-handlers",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "netlify-plugin-edge",
+  "name": "@netlify/plugin-edge-handlers",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",


### PR DESCRIPTION
This changes the plugin name to make it match our current convention of naming core plugins `@netlify/plugin-*`.

@shortdiv @calavera @mraerino What do you think?