### PR TITLE
Fix handlers directory name

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 name: netlify-plugin-edge
 inputs:
   - name: sourceDir
-    default: "handlers"
+    default: "edge-handlers"
   - name: outputDir
     default: ".netlify/handlers"
   - name: apiHost


### PR DESCRIPTION
The handlers directory name has been renamed to `edge-handlers`.