### PR TITLE
Fix typo

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,11 @@ async function assemble(src) {
   let registration = "";
   const functions = await fsPromises.readdir(src, { withFileTypes: true });
   for (const func of functions) {
-    if (!func.isFile() || (!func.name.endsWith(".js") && !func.name.endsWith(".ts"))) {
-      return;
+    if (
+      !func.isFile() ||
+      (!func.name.endsWith(".js") && !func.name.endsWith(".ts"))
+    ) {
+      continue;
     }
 
     const id = "func" + crypto.randomBytes(16).toString("hex");


### PR DESCRIPTION
When iterating over the functions and a function is not a edge handler, the loop should continue to the next item, not `return` from the whole function.