### PR TITLE
Fix path resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,10 +31,8 @@ async function assemble(src) {
 
     const id = "func" + crypto.randomBytes(16).toString("hex");
     const name = func.name.substr(0, func.name.length - 3); // remove extension //
-    imports += `import * as ${id} from "./${func.name}";\n`;
+    imports += `import * as ${id} from "${path.resolve(src, func.name)}";\n`;
     registration += `netlifyRegistry.set("${name}", ${id});\n`;
-
-    await fsPromises.copyFile(path.join(src, func.name), path.join(tmpDir, func.name));
 
     handlers.push(func);
   }


### PR DESCRIPTION
When function main files are being copied to the temporary directory, their local dependencies are not. The file path to those is broken, which makes Rollup break.

This PR solves this by not copying the function main files to the temporary directory. Instead, they are referred to using an absolute file path.