### PR TITLE
Fix `makeDir` call

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const makeDir = require("make-dir");
 const rollup = require("rollup");
 const nodeBabel = require("@rollup/plugin-babel");
 const babel = nodeBabel.babel;
@@ -81,7 +82,7 @@ async function writeBundle(buf, output, isLocal) {
   console.log(bundleInfo);
 
   if (isLocal) {
-    const dir = await fsPromises.mkdir(path.normalize(output));
+    await makeDir(output);
     const outputFile = path.join(output, bundleInfo.sha);
     await fsPromises.writeFile(outputFile, buf);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -474,6 +474,21 @@
         "sourcemap-codec": "^1.4.4"
       }
     },
+    "make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "requires": {
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/node": "^14.0.27",
     "esbuild": "^0.6.25",
     "fs": "0.0.1-security",
+    "make-dir": "^3.1.0",
     "path": "^0.12.7",
     "rollup": "^2.23.1",
     "rollup-plugin-esbuild": "^2.4.2",


### PR DESCRIPTION
When creating the final bundle, we ensure its directory exists using `fs.mkdir()`. However this will throw when the directory already exists. One quick way to fix this can be to use the `make-dir` library, which does not throw in that case. Also, `path.normalize()` is not required here since both Windows and Unix paths work with `fs.*()` calls (which `make-dir` uses under the hood).